### PR TITLE
Fix building with hatchling-1.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ tests = [
 [project.urls]
 Homepage = "https://github.com/matthiask/django-js-asset/"
 
+[tool.hatch.build.targets.wheel]
+packages = ["js_asset"]
+
 [tool.hatch.version]
 path = "js_asset/__init__.py"
 


### PR DESCRIPTION
Explicitly specify package name, as hatchling-1.19 now does not include packages that do not match the project name by default, and raises an error instead.