### PR TITLE
Fixed Django version for CSP nonce support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -272,10 +272,10 @@ stylesheet it renders (a ``JSON`` block is data, not executable, and
 deliberately gets none). There are three ways to get the nonce in, depending on
 your Django version.
 
-Django 6.2 and newer (built-in CSP)
+Django 6.1 and newer (built-in CSP)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Django 6.2 ships CSP support, and ``js_asset.Media`` plugs straight into it --
+Django 6.1 ships CSP support, and ``js_asset.Media`` plugs straight into it --
 no extra wiring. Configure CSP as usual:
 
 .. code-block:: python
@@ -314,7 +314,7 @@ calls ``media.render(attrs={"nonce": ...})`` for you:
 That single tag emits the merged import map and every script/stylesheet, each
 carrying the per-request nonce.
 
-Django 4.2 to 6.1 (with ``django-csp``)
+Django 4.2 to 6.0 (with ``django-csp``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Older Django has no built-in nonce, so use the third-party `django-csp


### PR DESCRIPTION
The `{% csp_nonce_attr %}` is included in 6.1 [see release notes](https://github.com/django/django/blob/b461519bf5973d7fc149560d2f99acdba71a437d/docs/releases/6.1.txt#L224)

the README suggests it's 6.2, I've updated the version numbers accordingly.

Django first shipped CSP support in 6.0 and it does support nonces too, but doesn't have the `{% csp_nonce_attr %}` or a `request.csp_nonce`. It would be possible to document how to make this all work with 6.0, but that would require a bigger change to the docs. You'd probably want to:
 - introduce 6.0 config after 6.1 and
 - pull the  `with_nonce()` function explanation and `media_with_nonce` template tag sections up from the django-csp section,
 - then the django-csp section can document it's config and how the view can use `with_nonce` and `request.csp_nonce`  and reference back to the `media_with_nonce` option. 

That seems a lot for a fly by PR so I left it at the simple version number change. Happy to give the full change a go if you'd like it.